### PR TITLE
Message ID plugin

### DIFF
--- a/Microsoft.Azure.ServiceBus.Plugins.sln
+++ b/Microsoft.Azure.ServiceBus.Plugins.sln
@@ -17,6 +17,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.ServiceBus.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.ServiceBus.Test.Shared", "test\Microsoft.Azure.ServiceBus.Test.Shared\Microsoft.Azure.ServiceBus.Test.Shared.csproj", "{63F75042-620C-4B08-BE41-D7EB64479A80}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{F7BC1BBC-D5D5-4E0A-9332-C9C841450F55}"
+	ProjectSection(SolutionItems) = preProject
+		docs\keyvault.md = docs\keyvault.md
+		docs\messageid.md = docs\messageid.md
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Microsoft.Azure.ServiceBus.Plugins.sln
+++ b/Microsoft.Azure.ServiceBus.Plugins.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.ServiceBus.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.ServiceBus.MessageId.Test", "test\Microsoft.Azure.ServiceBus.MessageId.Test\Microsoft.Azure.ServiceBus.MessageId.Test.csproj", "{F2FF1744-AE2B-440D-93AB-92C5B832FF25}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.ServiceBus.Test.Shared", "test\Microsoft.Azure.ServiceBus.Test.Shared\Microsoft.Azure.ServiceBus.Test.Shared.csproj", "{63F75042-620C-4B08-BE41-D7EB64479A80}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +39,10 @@ Global
 		{F2FF1744-AE2B-440D-93AB-92C5B832FF25}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F2FF1744-AE2B-440D-93AB-92C5B832FF25}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F2FF1744-AE2B-440D-93AB-92C5B832FF25}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63F75042-620C-4B08-BE41-D7EB64479A80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63F75042-620C-4B08-BE41-D7EB64479A80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63F75042-620C-4B08-BE41-D7EB64479A80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63F75042-620C-4B08-BE41-D7EB64479A80}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,5 +52,6 @@ Global
 		{DC8DC685-DCB5-47C7-A2B7-41D31EDDCAED} = {B18143EB-5FF4-4AFC-B086-709DC9B92546}
 		{7EAE339B-16CC-418C-BB17-070E10BE8283} = {7D8B793C-F4AC-432A-8EE7-2EE3C2B16EC1}
 		{F2FF1744-AE2B-440D-93AB-92C5B832FF25} = {B18143EB-5FF4-4AFC-B086-709DC9B92546}
+		{63F75042-620C-4B08-BE41-D7EB64479A80} = {B18143EB-5FF4-4AFC-B086-709DC9B92546}
 	EndGlobalSection
 EndGlobal

--- a/Microsoft.Azure.ServiceBus.Plugins.sln
+++ b/Microsoft.Azure.ServiceBus.Plugins.sln
@@ -1,15 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+VisualStudioVersion = 15.0.26430.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7D8B793C-F4AC-432A-8EE7-2EE3C2B16EC1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.ServiceBus.KeyVault", "src\Microsoft.Azure.ServiceBus.KeyVault\Microsoft.Azure.ServiceBus.KeyVault.csproj", "{F942A66E-A1B7-41C3-85E8-1A108D18F890}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ServiceBus.KeyVault", "src\Microsoft.Azure.ServiceBus.KeyVault\Microsoft.Azure.ServiceBus.KeyVault.csproj", "{F942A66E-A1B7-41C3-85E8-1A108D18F890}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{B18143EB-5FF4-4AFC-B086-709DC9B92546}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.ServiceBus.KeyVault.Test", "test\Microsoft.Azure.ServiceBus.KeyVault.Test\Microsoft.Azure.ServiceBus.KeyVault.Test.csproj", "{DC8DC685-DCB5-47C7-A2B7-41D31EDDCAED}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ServiceBus.KeyVault.Test", "test\Microsoft.Azure.ServiceBus.KeyVault.Test\Microsoft.Azure.ServiceBus.KeyVault.Test.csproj", "{DC8DC685-DCB5-47C7-A2B7-41D31EDDCAED}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.ServiceBus.MessageId", "src\Microsoft.Azure.ServiceBus.MessageId\Microsoft.Azure.ServiceBus.MessageId.csproj", "{7EAE339B-16CC-418C-BB17-070E10BE8283}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -25,6 +27,10 @@ Global
 		{DC8DC685-DCB5-47C7-A2B7-41D31EDDCAED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DC8DC685-DCB5-47C7-A2B7-41D31EDDCAED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DC8DC685-DCB5-47C7-A2B7-41D31EDDCAED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7EAE339B-16CC-418C-BB17-070E10BE8283}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7EAE339B-16CC-418C-BB17-070E10BE8283}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7EAE339B-16CC-418C-BB17-070E10BE8283}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7EAE339B-16CC-418C-BB17-070E10BE8283}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -32,5 +38,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F942A66E-A1B7-41C3-85E8-1A108D18F890} = {7D8B793C-F4AC-432A-8EE7-2EE3C2B16EC1}
 		{DC8DC685-DCB5-47C7-A2B7-41D31EDDCAED} = {B18143EB-5FF4-4AFC-B086-709DC9B92546}
+		{7EAE339B-16CC-418C-BB17-070E10BE8283} = {7D8B793C-F4AC-432A-8EE7-2EE3C2B16EC1}
 	EndGlobalSection
 EndGlobal

--- a/Microsoft.Azure.ServiceBus.Plugins.sln
+++ b/Microsoft.Azure.ServiceBus.Plugins.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ServiceBus.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.ServiceBus.MessageId", "src\Microsoft.Azure.ServiceBus.MessageId\Microsoft.Azure.ServiceBus.MessageId.csproj", "{7EAE339B-16CC-418C-BB17-070E10BE8283}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.ServiceBus.MessageId.Test", "test\Microsoft.Azure.ServiceBus.MessageId.Test\Microsoft.Azure.ServiceBus.MessageId.Test.csproj", "{F2FF1744-AE2B-440D-93AB-92C5B832FF25}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +33,10 @@ Global
 		{7EAE339B-16CC-418C-BB17-070E10BE8283}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EAE339B-16CC-418C-BB17-070E10BE8283}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EAE339B-16CC-418C-BB17-070E10BE8283}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2FF1744-AE2B-440D-93AB-92C5B832FF25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2FF1744-AE2B-440D-93AB-92C5B832FF25}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2FF1744-AE2B-440D-93AB-92C5B832FF25}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2FF1744-AE2B-440D-93AB-92C5B832FF25}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -39,5 +45,6 @@ Global
 		{F942A66E-A1B7-41C3-85E8-1A108D18F890} = {7D8B793C-F4AC-432A-8EE7-2EE3C2B16EC1}
 		{DC8DC685-DCB5-47C7-A2B7-41D31EDDCAED} = {B18143EB-5FF4-4AFC-B086-709DC9B92546}
 		{7EAE339B-16CC-418C-BB17-070E10BE8283} = {7D8B793C-F4AC-432A-8EE7-2EE3C2B16EC1}
+		{F2FF1744-AE2B-440D-93AB-92C5B832FF25} = {B18143EB-5FF4-4AFC-B086-709DC9B92546}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ See our [Contribution Guidelines](./.github/CONTRIBUTING.md).
 The folling plugins are included with this repository:
 
 * [Key Vault](./docs/keyvault.md)
+* [Message ID](./docs/messageid.md)

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -45,17 +45,21 @@ function Build-Solution
 
 function Run-UnitTests
 {
+    Write-Host "Running unit tests."
+
     if ($skipCodeCoverage)
     {
-        dotnet test $testProject -f $runtime
-        if (-not $?)
+        foreach ($test in ls ($projectFolder + '\test\**\*.Test.csproj')) 
         {
-            throw "Unit tests failed."
+            Write-Host "Testing $test"
+            dotnet test $test -f $runtime
+            if (-not $?)
+            {
+                throw "Unit tests failed."
+            }
         }
         return;
     }
-    
-    Write-Host "Running unit tests."
     
     if (-Not (Test-Path .\nuget.exe))
     {

--- a/docs/messageid.md
+++ b/docs/messageid.md
@@ -1,0 +1,27 @@
+# Message ID plugin for Azure Service Bus
+
+The Message ID plugin for Azure Service Bus allows for the message ID on outgoing messages to be set using custom logic.
+
+## How to use
+
+In order to use this plugin you will need to setup the following:
+
+1. An Azure subscription
+1. A Service Bus namespace
+
+## Example
+
+Below is a simple example of how to use the plugin.
+
+```csharp
+var messageIdPlugin = new MessageIdPlugin(() => Guid.NewGuid().ToString("N"));
+
+var queueClient = new QueueClient("{ServiceBusConnectionString}", "{ServiceBusEntityName}");
+queueClient.RegisterPlugin(messageIdPlugin);
+
+var message = new Message(Encoding.UTF8.GetBytes("Message with GUID message ID"));
+
+await queueClient.SendAsync(message);
+
+// message.MessageId will be assigned a GUID in a 32 digit format w/o hyphens or braces
+```

--- a/src/Microsoft.Azure.ServiceBus.MessageId/MessageIdPlugin.cs
+++ b/src/Microsoft.Azure.ServiceBus.MessageId/MessageIdPlugin.cs
@@ -1,13 +1,22 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.Azure.ServiceBus.Core;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.ServiceBus.MessageId
 {
-    /// <summary>Generate Azure Service Bus <see cref="Message"/> id.</summary>
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus.Core;
+
+    /// <summary>Generate Azure Service Bus <see cref="Message"/> <see cref="Message.MessageId"/> for outgoing messages.
+    /// <example>
+    /// var plugin = new MessageIdPlugin(() =&gt; Guid.NewGuid().ToString(N));
+    /// queueClient.RegisterPlugin(plugin);
+    /// </example>
+    /// </summary>
+    /// <remarks>If a message ID is assigned, the value will not be replaced by the plugin.</remarks>
     public class MessageIdPlugin : ServiceBusPlugin
     {
-        private readonly Func<string> messageIdGenerator;
+        private Func<string> messageIdGenerator;
 
         /// <summary>
         /// <inheritdoc cref="Name"/>
@@ -17,7 +26,7 @@ namespace Microsoft.Azure.ServiceBus.MessageId
         /// <summary>
         /// Create a new instance of <see cref="MessageIdPlugin"/>
         /// </summary>
-        /// <param name="messageIdGenerator"></param>
+        /// <param name="messageIdGenerator">Message ID generator to use.</param>
         public MessageIdPlugin(Func<string> messageIdGenerator)
         {
             this.messageIdGenerator = messageIdGenerator;

--- a/src/Microsoft.Azure.ServiceBus.MessageId/MessageIdPlugin.cs
+++ b/src/Microsoft.Azure.ServiceBus.MessageId/MessageIdPlugin.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.ServiceBus.MessageId
 
     /// <summary>Generate Azure Service Bus <see cref="Message"/> <see cref="Message.MessageId"/> for outgoing messages.
     /// <example>
-    /// var plugin = new MessageIdPlugin(() =&gt; Guid.NewGuid().ToString(N));
+    /// var plugin = new MessageIdPlugin(() =&gt; Guid.NewGuid().ToString("N"));
     /// queueClient.RegisterPlugin(plugin);
     /// </example>
     /// </summary>

--- a/src/Microsoft.Azure.ServiceBus.MessageId/MessageIdPlugin.cs
+++ b/src/Microsoft.Azure.ServiceBus.MessageId/MessageIdPlugin.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.ServiceBus.Core;
+
+namespace Microsoft.Azure.ServiceBus.MessageId
+{
+    /// <summary>Generate Azure Service Bus <see cref="Message"/> id.</summary>
+    public class MessageIdPlugin : ServiceBusPlugin
+    {
+        private readonly Func<string> messageIdGenerator;
+
+        /// <summary>
+        /// <inheritdoc cref="Name"/>
+        /// </summary>
+        public override string Name => "Microsoft.Azure.ServiceBus.MessageId";
+
+        /// <summary>
+        /// Create a new instance of <see cref="MessageIdPlugin"/>
+        /// </summary>
+        /// <param name="messageIdGenerator"></param>
+        public MessageIdPlugin(Func<string> messageIdGenerator)
+        {
+            this.messageIdGenerator = messageIdGenerator;
+        }
+
+        /// <summary>
+        /// Assign message id if it's not already assigned.
+        /// <param name="message">The <see cref="Message"/> to assign id to.</param>
+        /// </summary>
+        /// <returns><see cref="Message"/> with id.</returns>
+        public override Task<Message> BeforeMessageSend(Message message)
+        {
+            if (!string.IsNullOrEmpty(message.MessageId))
+            {
+                return base.BeforeMessageSend(message);
+            }
+
+            message.MessageId = messageIdGenerator();
+
+            return Task.FromResult(message);
+        }
+    }
+}

--- a/src/Microsoft.Azure.ServiceBus.MessageId/Microsoft.Azure.ServiceBus.MessageId.csproj
+++ b/src/Microsoft.Azure.ServiceBus.MessageId/Microsoft.Azure.ServiceBus.MessageId.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Microsoft.Azure.ServiceBus MessageId extension</Description>
+    <AssemblyTitle>Microsoft.Azure.ServiceBus.MessageId</AssemblyTitle>
+    <VersionPrefix>0.0.1-preview</VersionPrefix>
+    <Authors>Microsoft; Sean Feldman</Authors>
+    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AssemblyName>Microsoft.Azure.ServiceBus.MessageId</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../build/keyfile.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PackageId>Microsoft.Azure.ServiceBus.MessageId</PackageId>
+    <PackageTags>Azure;Service Bus;ServiceBus;.NET;AMQP;IoT;Queue;Topic;KeyVault;Encryption;Plugin</PackageTags>
+    <PackageReleaseNotes>https://github.com/Azure/azure-service-bus-dotnet-plugins/releases</PackageReleaseNotes>
+    <PackageIconUrl>https://raw.githubusercontent.com/Azure/azure-service-bus-dotnet-plugins/master/service-bus.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/Azure/azure-service-bus-dotnet-plugins</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/Azure/azure-service-bus-dotnet-plugins/master/LICENSE</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Microsoft.Azure.ServiceBus.MessageId.xml</DocumentationFile>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="0.0.6-preview" />
+  </ItemGroup>
+
+</Project>

--- a/test/Microsoft.Azure.ServiceBus.KeyVault.Test/EncryptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.KeyVault.Test/EncryptionTests.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Azure.ServiceBus.KeyVault.Test
     using System.Threading.Tasks;
     using Microsoft.Azure.ServiceBus.KeyVault;
     using Xunit;
-
+    using Microsoft.Azure.ServiceBus.Test.Shared;
+    
     public class EncryptionTests
     {
         [Fact]

--- a/test/Microsoft.Azure.ServiceBus.KeyVault.Test/EncryptionTests.cs
+++ b/test/Microsoft.Azure.ServiceBus.KeyVault.Test/EncryptionTests.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Azure.ServiceBus.KeyVault.Test
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Azure.ServiceBus.KeyVault;
-    using Xunit;
     using Microsoft.Azure.ServiceBus.Test.Shared;
-    
+    using Xunit;
+
     public class EncryptionTests
     {
         [Fact]

--- a/test/Microsoft.Azure.ServiceBus.KeyVault.Test/Microsoft.Azure.ServiceBus.KeyVault.Test.csproj
+++ b/test/Microsoft.Azure.ServiceBus.KeyVault.Test/Microsoft.Azure.ServiceBus.KeyVault.Test.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Azure.ServiceBus.KeyVault\Microsoft.Azure.ServiceBus.KeyVault.csproj" />
+    <ProjectReference Include="..\Microsoft.Azure.ServiceBus.Test.Shared\Microsoft.Azure.ServiceBus.Test.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.ServiceBus.MessageId.Test/Microsoft.Azure.ServiceBus.MessageId.Test.csproj
+++ b/test/Microsoft.Azure.ServiceBus.MessageId.Test/Microsoft.Azure.ServiceBus.MessageId.Test.csproj
@@ -1,0 +1,43 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyTitle>Microsoft.Azure.ServiceBus.MessageId.Test</AssemblyTitle>
+    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AssemblyName>Microsoft.Azure.ServiceBus.MessageId.Test</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../build/keyfile.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PackageId>Microsoft.Azure.ServiceBus.MessageId.Test</PackageId>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net46+win8</PackageTargetFallback>
+    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <Description />
+    <DelaySign>False</DelaySign>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Microsoft.Azure.ServiceBus.KeyVault.Test\DisplayTestMethodNameAttribute.cs" Link="DisplayTestMethodNameAttribute.cs" />
+    <Compile Include="..\Microsoft.Azure.ServiceBus.KeyVault.Test\TestUtility.cs" Link="TestUtility.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Azure.ServiceBus.MessageId\Microsoft.Azure.ServiceBus.MessageId.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/test/Microsoft.Azure.ServiceBus.MessageId.Test/When_MessageIdPlugin_is_used.cs
+++ b/test/Microsoft.Azure.ServiceBus.MessageId.Test/When_MessageIdPlugin_is_used.cs
@@ -1,14 +1,12 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace Microsoft.Azure.ServiceBus.MessageId.Test
 {
-    using System.Text;
+    using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.ServiceBus;
-    using Microsoft.Azure.ServiceBus.KeyVault.Test;
     using Xunit;
+    using Microsoft.Azure.ServiceBus.Test.Shared;
 
     public class When_MessageIdPlugin_is_used
     {

--- a/test/Microsoft.Azure.ServiceBus.MessageId.Test/When_MessageIdPlugin_is_used.cs
+++ b/test/Microsoft.Azure.ServiceBus.MessageId.Test/When_MessageIdPlugin_is_used.cs
@@ -1,0 +1,58 @@
+﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Azure.ServiceBus.MessageId.Test
+{
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus;
+    using Microsoft.Azure.ServiceBus.KeyVault.Test;
+    using Xunit;
+
+    public class When_MessageIdPlugin_is_used
+    {
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task Should_assign_message_id()
+        {
+            var message = new Message();
+            var generatedMessageId = Guid.Empty;
+            var plugin = new MessageIdPlugin(() =>
+            {
+                generatedMessageId = Guid.NewGuid();
+                return generatedMessageId.ToString("N");
+            });
+
+            var result = await plugin.BeforeMessageSend(message);
+
+            Assert.Equal(generatedMessageId, Guid.Parse(result.MessageId));
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task Should_not_assign_message_id_if_it_already_exists()
+        {
+            var originalMessageId = Guid.NewGuid().ToString();
+            var message = new Message
+            {
+                MessageId = originalMessageId
+            };
+            var plugin = new MessageIdPlugin(() => "this id should never be assigned");
+
+            var result = await plugin.BeforeMessageSend(message);
+
+            Assert.Equal(originalMessageId, result.MessageId);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public void Should_return_correct_plugin_name()
+        {
+            var plugin = new MessageIdPlugin(() => "");
+
+            Assert.Equal("Microsoft.Azure.ServiceBus.MessageId", plugin.Name);
+        }
+
+    }
+}

--- a/test/Microsoft.Azure.ServiceBus.Test.Shared/DisplayTestMethodNameAttribute.cs
+++ b/test/Microsoft.Azure.ServiceBus.Test.Shared/DisplayTestMethodNameAttribute.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Azure.ServiceBus.KeyVault.Test
+namespace Microsoft.Azure.ServiceBus.Test.Shared
 {
     using System.Reflection;
     using Microsoft.Extensions.PlatformAbstractions;

--- a/test/Microsoft.Azure.ServiceBus.Test.Shared/Microsoft.Azure.ServiceBus.Test.Shared.csproj
+++ b/test/Microsoft.Azure.ServiceBus.Test.Shared/Microsoft.Azure.ServiceBus.Test.Shared.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyTitle>Microsoft.Azure.ServiceBus.MessageId.Test</AssemblyTitle>
+    <AssemblyTitle>Microsoft.Azure.ServiceBus.KeyVault.Test</AssemblyTitle>
     <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyName>Microsoft.Azure.ServiceBus.MessageId.Test</AssemblyName>
+    <AssemblyName>Microsoft.Azure.ServiceBus.Test.Shared</AssemblyName>
     <AssemblyOriginatorKeyFile>../../build/keyfile.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>Microsoft.Azure.ServiceBus.MessageId.Test</PackageId>
+    <PackageId>Microsoft.Azure.ServiceBus.Test.Shared</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net46+win8</PackageTargetFallback>
     <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
@@ -17,12 +17,8 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Description />
     <DelaySign>False</DelaySign>
+    <RootNamespace>Microsoft.Azure.ServiceBus.Test.Shared</RootNamespace>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Azure.ServiceBus.MessageId\Microsoft.Azure.ServiceBus.MessageId.csproj" />
-    <ProjectReference Include="..\Microsoft.Azure.ServiceBus.Test.Shared\Microsoft.Azure.ServiceBus.Test.Shared.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
@@ -30,10 +26,6 @@
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Azure.ServiceBus.Test.Shared/TestUtility.cs
+++ b/test/Microsoft.Azure.ServiceBus.Test.Shared/TestUtility.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Azure.ServiceBus.KeyVault.Test
+namespace Microsoft.Azure.ServiceBus.Test.Shared
 {
     using System;
     using System.Diagnostics;


### PR DESCRIPTION
## Description

By default, `Message` doesn't have its `MessageId` assigned.
This plugin allows to register a factory to generate message IDs on all outgoing messages that do not have their message ID assigned.

This completes https://github.com/Azure/azure-service-bus-dotnet/issues/19 that was taken out.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.