### PR TITLE
Enhancement to MessageIdPlugin

### DIFF
--- a/src/Microsoft.Azure.ServiceBus.MessageId/MessageIdPlugin.cs
+++ b/src/Microsoft.Azure.ServiceBus.MessageId/MessageIdPlugin.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.ServiceBus.MessageId
     /// <remarks>If a message ID is assigned, the value will not be replaced by the plugin.</remarks>
     public class MessageIdPlugin : ServiceBusPlugin
     {
-        private Func<string> messageIdGenerator;
+        private Func<Message, string> messageIdGenerator;
 
         /// <summary>
         /// <inheritdoc cref="Name"/>
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.ServiceBus.MessageId
         /// Create a new instance of <see cref="MessageIdPlugin"/>
         /// </summary>
         /// <param name="messageIdGenerator">Message ID generator to use.</param>
-        public MessageIdPlugin(Func<string> messageIdGenerator)
+        public MessageIdPlugin(Func<Message, string> messageIdGenerator)
         {
             this.messageIdGenerator = messageIdGenerator;
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.ServiceBus.MessageId
                 return base.BeforeMessageSend(message);
             }
 
-            message.MessageId = messageIdGenerator();
+            message.MessageId = messageIdGenerator(message);
 
             return Task.FromResult(message);
         }

--- a/test/Microsoft.Azure.ServiceBus.MessageId.Test/When_MessageIdPlugin_is_used.cs
+++ b/test/Microsoft.Azure.ServiceBus.MessageId.Test/When_MessageIdPlugin_is_used.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.ServiceBus.MessageId.Test
         {
             var message = new Message();
             var generatedMessageId = Guid.Empty;
-            var plugin = new MessageIdPlugin(() =>
+            var plugin = new MessageIdPlugin(msg =>
             {
                 generatedMessageId = Guid.NewGuid();
                 return generatedMessageId.ToString("N");
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.ServiceBus.MessageId.Test
             {
                 MessageId = originalMessageId
             };
-            var plugin = new MessageIdPlugin(() => "this id should never be assigned");
+            var plugin = new MessageIdPlugin(msg => "this id should never be assigned");
 
             var result = await plugin.BeforeMessageSend(message);
 
@@ -47,9 +47,24 @@ namespace Microsoft.Azure.ServiceBus.MessageId.Test
         [DisplayTestMethodName]
         public void Should_return_correct_plugin_name()
         {
-            var plugin = new MessageIdPlugin(() => "");
+            var plugin = new MessageIdPlugin(msg => "");
 
             Assert.Equal("Microsoft.Azure.ServiceBus.MessageId", plugin.Name);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task Should_be_able_to_set_message_id_based_on_message_data()
+        {
+            var message = new Message
+            {
+                UserProperties = { { "CustomProperty", "CustomValue" } }
+            };
+
+            var plugin = new MessageIdPlugin(msg => msg.UserProperties["CustomProperty"].ToString());
+            var result = await plugin.BeforeMessageSend(message);
+
+            Assert.Equal("CustomValue", result.MessageId);
         }
 
     }


### PR DESCRIPTION
`MessageIdPlugin` factory registered with the plugin does not have access to the processed message.

This PR addresses this issue by allowing factory to access the processed message.
By doing so, the plugin can implement hashed IDs to perform message de-duplication natively or generate message IDs that are tied into message metadata.

Example:
```c#
new MessageIdPlugin(msg => msg.UserProperties["CustomPropertyToBeUsedForMessageId"].ToString());
```